### PR TITLE
[curl] Update to 7.78.0. Fixes JB#54974

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "curl"]
 	path = curl
-	url = https://git.sailfishos.org/mirror/curl.git
+	url = https://github.com/sailfishos-mirror/curl.git

--- a/rpm/curl.changes
+++ b/rpm/curl.changes
@@ -16,7 +16,7 @@
 * Mon Jan 12 2015 John Brooks <john.brooks@jolla.com> - 7.40.0
 - Update to 7.40.0
 
-* Wed Nov 8 2014 Pasi Sjöholm <pasi.sjoholm@jollamobile.com> - 7.36.0-3
+* Sat Nov 8 2014 Pasi Sjöholm <pasi.sjoholm@jollamobile.com> - 7.36.0-3
 - Fix CVE-2014-3707
 
 * Wed Oct 29 2014 Pasi Sjöholm <pasi.sjoholm@jollamobile.com> - 7.36.0-2
@@ -39,7 +39,7 @@
 * Wed Aug  8 2012 Islam Amer <islam.amer@jollamobile.com> -7.25.0
 - Use ca-path instead of ca-bundle, fixes MER#490
 
-* Thu Mar 05 2012 Marko Saukko <sage@merproject.org> - 7.25.0
+* Mon Mar 05 2012 Marko Saukko <sage@merproject.org> - 7.25.0
 - Fixes MER#248: CVE-2012-0036 curl URL sanitization vulnerability
 
 * Fri Nov 11 2011 Marko Saukko <marko.saukko@cybercom.com> - 7.22.0

--- a/rpm/curl.spec
+++ b/rpm/curl.spec
@@ -1,6 +1,6 @@
 Name:       curl
 Summary:    A utility for getting files from remote servers (FTP, HTTP, and others)
-Version:    7.77.0
+Version:    7.78.0
 Release:    1
 License:    MIT
 URL:        https://curl.se/
@@ -61,7 +61,6 @@ use cURL's capabilities internally.
     --with-openssl \
     --without-brotli \
     --without-libidn2 \
-    --without-libmetalink \
     --without-libssh
 
 %make_build


### PR DESCRIPTION
Fixes a bunch CVEs. Updated submodule url and fixed changelog. Libmetalink support was removed and thus it's configuration flag was removed as well.