### PR TITLE
[curl] Update to 8.4.0

### DIFF
--- a/rpm/curl.spec
+++ b/rpm/curl.spec
@@ -1,6 +1,6 @@
 Name:       curl
 Summary:    A utility for getting files from remote servers (FTP, HTTP, and others)
-Version:    7.87.0
+Version:    8.4.0
 Release:    1
 License:    MIT
 URL:        https://curl.se/


### PR DESCRIPTION
Not tested yet. (Builds correctly still of course).
They claim to never break ABI, and note that it is the case especially for this major version.