### PR TITLE
Update to version 8.18.0

### DIFF
--- a/rpm/0101-curl-7.32.0-multilib.patch
+++ b/rpm/0101-curl-7.32.0-multilib.patch
@@ -1,6 +1,6 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 6bb4e674cdc953f5c0048aa84172539900725166 Mon Sep 17 00:00:00 2001
 From: Jan Macku <jamacku@redhat.com>
-Date: Mon, 25 Aug 2025 10:41:12 +0200
+Date: Tue, 16 Dec 2025 10:04:40 +0100
 Subject: [PATCH] prevent multilib conflicts on the curl-config script
 
 ---
@@ -10,7 +10,7 @@ Subject: [PATCH] prevent multilib conflicts on the curl-config script
  3 files changed, 9 insertions(+), 19 deletions(-)
 
 diff --git a/curl-config.in b/curl-config.in
-index ce23519..bb43ca8 100644
+index a1c8185875..bb43ca8335 100644
 --- a/curl-config.in
 +++ b/curl-config.in
 @@ -74,7 +74,7 @@ while test "$#" -gt 0; do
@@ -26,7 +26,7 @@ index ce23519..bb43ca8 100644
      ;;
  
    --libs)
--    if test "@libdir@" != '/usr/lib' -a "@libdir@" != '/usr/lib64'; then
+-    if test "@libdir@" != '/usr/lib' && test "@libdir@" != '/usr/lib64'; then
 -      curllibdir="-L@libdir@ "
 -    else
 -      curllibdir=''
@@ -61,7 +61,7 @@ index ce23519..bb43ca8 100644
  
    *)
 diff --git a/docs/curl-config.md b/docs/curl-config.md
-index 12ad245..fa0e03d 100644
+index 12ad245b79..fa0e03d273 100644
 --- a/docs/curl-config.md
 +++ b/docs/curl-config.md
 @@ -87,7 +87,9 @@ no, one or several names. If more than one name, they appear comma-separated.
@@ -76,7 +76,7 @@ index 12ad245..fa0e03d 100644
  ## `--version`
  
 diff --git a/libcurl.pc.in b/libcurl.pc.in
-index c0ba524..f3645e1 100644
+index c0ba5244a8..f3645e1748 100644
 --- a/libcurl.pc.in
 +++ b/libcurl.pc.in
 @@ -28,6 +28,7 @@ libdir=@libdir@
@@ -87,3 +87,5 @@ index c0ba524..f3645e1 100644
  
  Name: libcurl
  URL: https://curl.se/
+-- 
+2.52.0

--- a/rpm/curl.spec
+++ b/rpm/curl.spec
@@ -1,9 +1,9 @@
 Name:       curl
 Summary:    A utility for getting files from remote servers (FTP, HTTP, and others)
-Version:    8.16.0
+Version:    8.18.0
 Release:    1
 License:    MIT
-URL:        https://curl.se/
+URL:        https://github.com/sailfishos/curl
 Source0:    %{name}-%{version}.tar.gz
 # patch making libcurl multilib ready
 Patch101:   0101-curl-7.32.0-multilib.patch

--- a/rpm/curl.spec
+++ b/rpm/curl.spec
@@ -54,6 +54,8 @@ use cURL's capabilities internally.
     --disable-ldap \
     --disable-ldaps \
     --disable-manual \
+    --with-ca-bundle=%{_sysconfdir}/pki/tls/certs/ca-bundle.crt \
+    --with-ca-path=%{_sysconfdir}/ssl/certs \
     --with-libpsl \
     --with-nghttp2 \
     --with-openssl \


### PR DESCRIPTION
Force ca-bundle and ca-path to prevent incorrectly detected values. Use packaging URL in spec.